### PR TITLE
Use event_member for event_body in Lark grammar

### DIFF
--- a/vyper/ast/grammar.lark
+++ b/vyper/ast/grammar.lark
@@ -69,7 +69,7 @@ function_def: [decorators] function_sig ":" body
 _EVENT_DECL: "event"
 event_member: NAME ":" type
 indexed_event_arg: NAME ":" "indexed" "(" type ")"
-event_body: _NEWLINE _INDENT ((variable | indexed_event_arg) _NEWLINE)+ _DEDENT
+event_body: _NEWLINE _INDENT ((event_member | indexed_event_arg) _NEWLINE)+ _DEDENT
 // Events which use no args use a pass statement instead
 event_def: _EVENT_DECL NAME ":" ( event_body | _PASS )
 


### PR DESCRIPTION
### What I did

The `event_body` rule in the Lark grammar uses `variable` instead of the `event_member` declared 2 lines above:
`event_body: _NEWLINE _INDENT ((variable | indexed_event_arg) _NEWLINE)+ _DEDENT` 

This causes event members to be parsed as the generic `variable`. Using `event_member` instead parses event member with their own specific type.

### How I did it

Update `grammar.lark`

### How to verify it

Parsing:
```
event Event:
    a: uint256
    b: uint256
```

returns:
```
module
  event_def
    Event
    event_body
      event_member
        a
        type	uint256
      event_member
        b
        type	uint256
```

instead of:
```
module
  event_def
    Event
    event_body
      variable
        a
        type	uint256
      variable
        b
        type	uint256
```

### Commit message

Use event_member for event_body in Lark grammar

### Description for the changelog

### Cute Animal Picture

![image](https://user-images.githubusercontent.com/25791237/197380098-01649d2b-09e6-47bc-978e-5152c8764b07.png)